### PR TITLE
Fix webpack config unexpected identifier error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ const PATHS  = {
   build: path.join(__dirname, 'build')
 };
 
-const VERSION = () => {
+const VERSION = (() => {
   var v;
 
   try {
@@ -29,7 +29,7 @@ const VERSION = () => {
   }
 
   return v;
-}();
+})();
 
 // Used to configure Babel (see: `.babelrc` file)
 process.env.BABEL_ENV = TARGET;


### PR DESCRIPTION
I was getting an error about unexpected identifier with npm run dev with node 6.0


```
/Users/biocmd/Sites/franklin/webpack.config.js:32
}();
 ^
SyntaxError: Unexpected token (
    at Object.exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:513:28)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at module.exports (/Users/biocmd/Sites/franklin/node_modules/webpack/bin/convert-argv.js:80:13)
    at Object.<anonymous> (/Users/biocmd/Sites/franklin/node_modules/webpack/bin/webpack.js:39:40)

npm ERR! Darwin 13.4.0
npm ERR! argv "/usr/local/Cellar/node/6.2.1/bin/node" "/usr/local/bin/npm" "run" "build"
npm ERR! node v6.2.1
npm ERR! npm  v3.9.3
npm ERR! code ELIFECYCLE
npm ERR! franklin@1.0.0 build: `NODE_ENV=production webpack`
npm ERR! Exit status 1
```

I figured it might be fix it if the function was wrapped in parens and it did seem to