### PR TITLE
Annotation form enhancement

### DIFF
--- a/app/Controller.js
+++ b/app/Controller.js
@@ -69,6 +69,7 @@ export default class Controller {
   }
 
   onSelectAnnotation({ labelId, annotation }) {
+    this.store.clearSelection();
     this.store.selectAnnotation(labelId, annotation);
   }
 

--- a/app/components/AnnotationForm.jsx
+++ b/app/components/AnnotationForm.jsx
@@ -7,8 +7,8 @@ import { emptySelection } from '../defaults';
 const { instanceOf, object } = PropTypes;
 
 const emptyState = {
-  annotationPositionFrom: undefined,
-  annotationPositionTo: undefined,
+  annotationPositionFrom: '',
+  annotationPositionTo: '',
   annotationComment: '',
   labelId: '',
   annotationId: null,
@@ -21,6 +21,7 @@ class AnnotationForm extends Component {
     this.state = emptyState;
 
     this.onSubmit = this.onSubmit.bind(this);
+    this.onSelectionChange = this.onSelectionChange.bind(this);
     this.onPositionFromChange = this.onPositionFromChange.bind(this);
     this.onPositionToChange = this.onPositionToChange.bind(this);
     this.onLabelChange = this.onLabelChange.bind(this);
@@ -40,9 +41,7 @@ class AnnotationForm extends Component {
     });
 
     this.context.controller.on(Events.CHANGE_SELECTION, (selection) => {
-      if (selection === emptySelection) {
-        this.reset();
-      }
+      this.onSelectionChange(selection);
     });
   }
 
@@ -60,6 +59,17 @@ class AnnotationForm extends Component {
     });
 
     this.context.controller.dispatch('action:clear-selection');
+  }
+
+  onSelectionChange(selection) {
+    if (selection === emptySelection || null !== this.state.annotationId) {
+      this.reset();
+    }
+
+    this.setState({
+      annotationPositionFrom: selection.from !== undefined ? selection.from + 1 : '',
+      annotationPositionTo: selection.to !== undefined ? selection.to + 1 : '',
+    });
   }
 
   onPositionFromChange(event) {

--- a/app/components/__tests__/AnnotationForm-test.js
+++ b/app/components/__tests__/AnnotationForm-test.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { expect } from 'chai';
+import Immutable from 'immutable';
+import sinon from 'sinon';
+
+import AnnotationForm from '../AnnotationForm';
+import { defaultLabels } from '../../defaults';
+import { Events } from '../../Store';
+
+describe('<AnnotationForm />', () => {
+  const sequence = new Immutable.List('ATTTGCGTCG'.split(''));
+
+  let context, spyOn;
+
+  beforeEach(() => {
+    spyOn = sinon.spy();
+
+    context = {
+      controller: {
+        on: spyOn,
+      }
+    };
+  });
+
+  it('renders an annotation form', () => {
+    const wrapper = shallow(
+      <AnnotationForm
+        sequence={sequence}
+        labels={defaultLabels}
+      />,
+      {context}
+    );
+
+    expect(wrapper.find('input[type="submit"]')).to.have.length(1);
+    expect(wrapper.find('input[type="number"]')).to.have.length(2);
+    expect(wrapper.find('select')).to.have.length(1);
+    expect(wrapper.find('textarea')).to.have.length(1);
+  });
+
+  it('registers to selection change', () => {
+    const wrapper = mount(
+      <AnnotationForm
+        sequence={sequence}
+        labels={defaultLabels}
+      />,
+      {context}
+    );
+
+    expect(spyOn.calledWith(Events.CHANGE_SELECTION)).to.be.true;
+  });
+
+  it('updates annotation form with selection', () => {
+    const selection = {from: 2, to: 4};
+    const wrapper = mount(
+      <AnnotationForm
+        sequence={sequence}
+        labels={defaultLabels}
+      />,
+      {context}
+    );
+
+    wrapper.instance().onSelectionChange(selection);
+
+    expect(wrapper.find('input[type="number"][value=3]')).to.have.length(1);
+    expect(wrapper.find('input[type="number"][value=5]')).to.have.length(1);
+  });
+
+  it('updates annotation form with partial selection', () => {
+    const selection = {from: 2, to: undefined};
+    const wrapper = mount(
+      <AnnotationForm
+        sequence={sequence}
+        labels={defaultLabels}
+      />,
+      {context}
+    );
+
+    wrapper.instance().onSelectionChange(selection);
+
+    expect(wrapper.find('input[type="number"][value=3]')).to.have.length(1);
+    expect(wrapper.find({placeholder:"To", type:"number", value:''})).to.have.length(1);
+  });
+});


### PR DESCRIPTION
Allow to start and fill an annotation via sequence clicks (#33).
Also fix a warning: `AnnotationForm is changing a controlled input of type number to be uncontrolled.`