### PR TITLE
Annotations must be oriented

### DIFF
--- a/app/components/Annotation/Line.jsx
+++ b/app/components/Annotation/Line.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+
+const tickPosition = {
+  x: 5,
+  y: 4,
+};
+
+const Line = (props) => (
+  <g>
+    <line
+      x1={props.x1}
+      x2={props.x2}
+      y1={props.y1}
+      y2={props.y2}
+      className="annotation-segment"
+      stroke={props.color}
+    />
+    {props.hasTick ?
+      <line
+        x1={props.isReverse ? props.x1 : props.x2}
+        x2={props.isReverse ? props.x1 + tickPosition.x : props.x2 - tickPosition.x}
+        y1={props.isReverse ? props.y1 : props.y2}
+        y2={props.isReverse ? props.y1 + tickPosition.y : props.y2 - tickPosition.y}
+        stroke={props.color}
+        className={`annotation-tick ${props.isReverse ? 'reverse' : 'forward'}`}
+      /> : null
+    }
+  </g>
+);
+
+Line.propTypes = {
+  x1: React.PropTypes.number.isRequired,
+  x2: React.PropTypes.number.isRequired,
+  y1: React.PropTypes.number.isRequired,
+  y2: React.PropTypes.number.isRequired,
+  color: React.PropTypes.string.isRequired,
+  hasTick: React.PropTypes.bool.isRequired,
+  isReverse: React.PropTypes.bool.isRequired,
+};
+
+export default Line;

--- a/app/components/Annotation/__tests__/Annotation-test.js
+++ b/app/components/Annotation/__tests__/Annotation-test.js
@@ -74,8 +74,9 @@ describe('<Annotation />', () => {
       />
     );
 
-    expect(wrapper.find('g')).to.have.length(1);
+    expect(wrapper.find('g')).to.have.length(2);
     expect(wrapper.find('line')).to.have.length(1);
+    expect(wrapper.find('circle')).to.have.length(1);
   });
 
   it('renders segments when new props are received', () => {
@@ -125,6 +126,119 @@ describe('<Annotation />', () => {
       />
     );
 
-    wrapper.find('g').simulate('click');
+    wrapper.find('g').first().simulate('click');
+  });
+
+  it('should NOT render the tick if annotation is a unit (dimension == 1)', () => {
+    const labelId = 0;
+    const label = defaultLabels.get(labelId);
+    const segments = [
+      { x1: 0, y1: 0, x2: 0, y2: 5 },
+    ];
+
+    // force same positions
+    const annotation = Object.assign({}, label.annotations.first(), {
+      positionFrom: 1,
+      positionTo: 1,
+    });
+
+    const wrapper = shallow(
+      <Annotation
+        annotation={annotation}
+        label={label}
+        labelId={labelId}
+        getAnnotationSegments={() => { return segments; }}
+        isSelected={false}
+        onClick={() => {}}
+      />
+    );
+
+    expect(wrapper.find('g')).to.have.length(2);
+    expect(wrapper.find('line')).to.have.length(1);
+    expect(wrapper.find('circle')).to.have.length(0);
+  });
+
+  it('should render a tick', () => {
+    const labelId = 0;
+    const label = defaultLabels.get(labelId);
+    const annotation = label.annotations.first();
+    const segments = [
+      { x1: 0, y1: 1, x2: 0, y2: 5 },
+    ];
+
+    const wrapper = shallow(
+      <Annotation
+        annotation={annotation}
+        label={label}
+        labelId={labelId}
+        getAnnotationSegments={() => { return segments; }}
+        isSelected={false}
+        onClick={() => {}}
+      />
+    );
+
+    expect(wrapper.find('g')).to.have.length(2);
+    expect(wrapper.find('line')).to.have.length(1);
+    expect(wrapper.find('circle')).to.have.length(1);
+    expect(wrapper.find('circle').props().cx).to.equal(0);
+    expect(wrapper.find('circle').props().cy).to.equal(5);
+  });
+
+  it('should render a tick with multiple segments', () => {
+    const labelId = 0;
+    const label = defaultLabels.get(labelId);
+    const annotation = label.annotations.first();
+    const segments = [
+      { x1: 0, y1: 1, x2: 0, y2: 5 },
+      { x1: 1, y1: 2, x2: 1, y2: 6 },
+    ];
+
+    const wrapper = shallow(
+      <Annotation
+        annotation={annotation}
+        label={label}
+        labelId={labelId}
+        getAnnotationSegments={() => { return segments; }}
+        isSelected={false}
+        onClick={() => {}}
+      />
+    );
+
+    expect(wrapper.find('g')).to.have.length(3);
+    expect(wrapper.find('line')).to.have.length(2);
+    expect(wrapper.find('circle')).to.have.length(1);
+    expect(wrapper.find('circle').props().cx).to.equal(1);
+    expect(wrapper.find('circle').props().cy).to.equal(6);
+  });
+
+  it('should render a tick for inverted annotation', () => {
+    const labelId = 0;
+    const label = defaultLabels.get(labelId);
+    const segments = [
+      { x1: 0, y1: 1, x2: 0, y2: 5 },
+      { x1: 1, y1: 2, x2: 1, y2: 6 },
+    ];
+
+    const annotation = Object.assign({}, label.annotations.first(), {
+      positionFrom: 10,
+      positionTo: 1,
+    });
+
+    const wrapper = shallow(
+      <Annotation
+        annotation={annotation}
+        label={label}
+        labelId={labelId}
+        getAnnotationSegments={() => { return segments; }}
+        isSelected={false}
+        onClick={() => {}}
+      />
+    );
+
+    expect(wrapper.find('g')).to.have.length(3);
+    expect(wrapper.find('line')).to.have.length(2);
+    expect(wrapper.find('circle')).to.have.length(1);
+    expect(wrapper.find('circle').props().cx).to.equal(0);
+    expect(wrapper.find('circle').props().cy).to.equal(1);
   });
 });

--- a/app/components/Annotation/__tests__/Annotation-test.js
+++ b/app/components/Annotation/__tests__/Annotation-test.js
@@ -75,8 +75,7 @@ describe('<Annotation />', () => {
     );
 
     expect(wrapper.find('g')).to.have.length(2);
-    expect(wrapper.find('line')).to.have.length(1);
-    expect(wrapper.find('circle')).to.have.length(1);
+    expect(wrapper.find('line')).to.have.length(2);
   });
 
   it('renders segments when new props are received', () => {
@@ -104,7 +103,7 @@ describe('<Annotation />', () => {
     // test starts here
     wrapper.setProps({ getAnnotationSegments: () => { return segments; } });
 
-    expect(wrapper.find('line')).to.have.length(1);
+    expect(wrapper.find('line')).to.have.length(2);
   });
 
   it('dispatches an action on click', () => {
@@ -155,7 +154,7 @@ describe('<Annotation />', () => {
 
     expect(wrapper.find('g')).to.have.length(2);
     expect(wrapper.find('line')).to.have.length(1);
-    expect(wrapper.find('circle')).to.have.length(0);
+    expect(wrapper.find('.annotation-tick')).to.have.length(0);
   });
 
   it('should render a tick', () => {
@@ -178,10 +177,9 @@ describe('<Annotation />', () => {
     );
 
     expect(wrapper.find('g')).to.have.length(2);
-    expect(wrapper.find('line')).to.have.length(1);
-    expect(wrapper.find('circle')).to.have.length(1);
-    expect(wrapper.find('circle').props().cx).to.equal(0);
-    expect(wrapper.find('circle').props().cy).to.equal(5);
+    expect(wrapper.find('line')).to.have.length(2);
+    expect(wrapper.find('.annotation-tick.forward')).to.have.length(1);
+    expect(wrapper.find('.annotation-tick.reverse')).to.have.length(0);
   });
 
   it('should render a tick with multiple segments', () => {
@@ -205,10 +203,9 @@ describe('<Annotation />', () => {
     );
 
     expect(wrapper.find('g')).to.have.length(3);
-    expect(wrapper.find('line')).to.have.length(2);
-    expect(wrapper.find('circle')).to.have.length(1);
-    expect(wrapper.find('circle').props().cx).to.equal(1);
-    expect(wrapper.find('circle').props().cy).to.equal(6);
+    expect(wrapper.find('line')).to.have.length(3);
+    expect(wrapper.find('.annotation-tick.forward')).to.have.length(1);
+    expect(wrapper.find('.annotation-tick.reverse')).to.have.length(0);
   });
 
   it('should render a tick for reverse annotation', () => {
@@ -236,9 +233,8 @@ describe('<Annotation />', () => {
     );
 
     expect(wrapper.find('g')).to.have.length(3);
-    expect(wrapper.find('line')).to.have.length(2);
-    expect(wrapper.find('circle')).to.have.length(1);
-    expect(wrapper.find('circle').props().cx).to.equal(0);
-    expect(wrapper.find('circle').props().cy).to.equal(1);
+    expect(wrapper.find('line')).to.have.length(3);
+    expect(wrapper.find('.annotation-tick.forward')).to.have.length(0);
+    expect(wrapper.find('.annotation-tick.reverse')).to.have.length(1);
   });
 });

--- a/app/components/Annotation/__tests__/Annotation-test.js
+++ b/app/components/Annotation/__tests__/Annotation-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { expect } from 'chai';
 import Immutable from 'immutable';
 import { defaultLabels } from '../../../defaults';
@@ -9,6 +9,7 @@ import sinon from 'sinon';
 const { describe, it } = global;
 
 import Annotation from '../presenter';
+import Line from '../Line';
 
 describe('<Annotation />', () => {
 
@@ -74,8 +75,8 @@ describe('<Annotation />', () => {
       />
     );
 
-    expect(wrapper.find('g')).to.have.length(2);
-    expect(wrapper.find('line')).to.have.length(2);
+    expect(wrapper.find('g')).to.have.length(1);
+    expect(wrapper.find(Line)).to.have.length(1);
   });
 
   it('renders segments when new props are received', () => {
@@ -98,12 +99,12 @@ describe('<Annotation />', () => {
     );
 
     expect(wrapper.find('g')).to.have.length(1);
-    expect(wrapper.find('line')).to.have.length(0);
+    expect(wrapper.find(Line)).to.have.length(0);
 
     // test starts here
     wrapper.setProps({ getAnnotationSegments: () => { return segments; } });
 
-    expect(wrapper.find('line')).to.have.length(2);
+    expect(wrapper.find(Line)).to.have.length(1);
   });
 
   it('dispatches an action on click', () => {
@@ -141,7 +142,7 @@ describe('<Annotation />', () => {
       positionTo: 1,
     });
 
-    const wrapper = shallow(
+    const wrapper = mount(
       <Annotation
         annotation={annotation}
         label={label}
@@ -153,7 +154,7 @@ describe('<Annotation />', () => {
     );
 
     expect(wrapper.find('g')).to.have.length(2);
-    expect(wrapper.find('line')).to.have.length(1);
+    expect(wrapper.find(Line)).to.have.length(1);
     expect(wrapper.find('.annotation-tick')).to.have.length(0);
   });
 
@@ -165,7 +166,7 @@ describe('<Annotation />', () => {
       { x1: 0, y1: 1, x2: 0, y2: 5 },
     ];
 
-    const wrapper = shallow(
+    const wrapper = mount(
       <Annotation
         annotation={annotation}
         label={label}
@@ -177,7 +178,7 @@ describe('<Annotation />', () => {
     );
 
     expect(wrapper.find('g')).to.have.length(2);
-    expect(wrapper.find('line')).to.have.length(2);
+    expect(wrapper.find(Line)).to.have.length(1);
     expect(wrapper.find('.annotation-tick.forward')).to.have.length(1);
     expect(wrapper.find('.annotation-tick.reverse')).to.have.length(0);
   });
@@ -191,7 +192,7 @@ describe('<Annotation />', () => {
       { x1: 1, y1: 2, x2: 1, y2: 6 },
     ];
 
-    const wrapper = shallow(
+    const wrapper = mount(
       <Annotation
         annotation={annotation}
         label={label}
@@ -203,7 +204,7 @@ describe('<Annotation />', () => {
     );
 
     expect(wrapper.find('g')).to.have.length(3);
-    expect(wrapper.find('line')).to.have.length(3);
+    expect(wrapper.find(Line)).to.have.length(2);
     expect(wrapper.find('.annotation-tick.forward')).to.have.length(1);
     expect(wrapper.find('.annotation-tick.reverse')).to.have.length(0);
   });
@@ -221,7 +222,7 @@ describe('<Annotation />', () => {
       positionTo: 1,
     });
 
-    const wrapper = shallow(
+    const wrapper = mount(
       <Annotation
         annotation={annotation}
         label={label}
@@ -232,8 +233,7 @@ describe('<Annotation />', () => {
       />
     );
 
-    expect(wrapper.find('g')).to.have.length(3);
-    expect(wrapper.find('line')).to.have.length(3);
+    expect(wrapper.find(Line)).to.have.length(2);
     expect(wrapper.find('.annotation-tick.forward')).to.have.length(0);
     expect(wrapper.find('.annotation-tick.reverse')).to.have.length(1);
   });

--- a/app/components/Annotation/__tests__/Annotation-test.js
+++ b/app/components/Annotation/__tests__/Annotation-test.js
@@ -211,7 +211,7 @@ describe('<Annotation />', () => {
     expect(wrapper.find('circle').props().cy).to.equal(6);
   });
 
-  it('should render a tick for inverted annotation', () => {
+  it('should render a tick for reverse annotation', () => {
     const labelId = 0;
     const label = defaultLabels.get(labelId);
     const segments = [

--- a/app/components/Annotation/__tests__/Line-test.js
+++ b/app/components/Annotation/__tests__/Line-test.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+// see: https://github.com/mochajs/mocha/issues/1847
+const { describe, it } = global;
+
+import Line from '../Line';
+
+
+describe('<Line />', () => {
+
+  it('renders itself', () => {
+    const wrapper = shallow(
+      <Line
+        x1={0}
+        y1={0}
+        x2={1}
+        y2={1}
+        color={'#fff'}
+        hasTick={false}
+        isReverse={false}
+      />
+    );
+
+    expect(wrapper.find('g')).to.have.length(1);
+    expect(wrapper.find('line')).to.have.length(1);
+    expect(wrapper.find('.annotation-tick')).to.have.length(0);
+  });
+
+  it('can render a tick', () => {
+    const wrapper = shallow(
+      <Line
+        x1={0}
+        y1={0}
+        x2={1}
+        y2={1}
+        color={'#fff'}
+        hasTick
+        isReverse={false}
+      />
+    );
+
+    expect(wrapper.find('g')).to.have.length(1);
+    expect(wrapper.find('line')).to.have.length(2);
+    expect(wrapper.find('.annotation-tick')).to.have.length(1);
+    expect(wrapper.find('.annotation-tick.forward')).to.have.length(1);
+  });
+
+  it('can render a tick for a reverse annotation', () => {
+    const wrapper = shallow(
+      <Line
+        x1={0}
+        y1={0}
+        x2={1}
+        y2={1}
+        color={'#fff'}
+        hasTick
+        isReverse
+      />
+    );
+
+    expect(wrapper.find('g')).to.have.length(1);
+    expect(wrapper.find('line')).to.have.length(2);
+    expect(wrapper.find('.annotation-tick')).to.have.length(1);
+    expect(wrapper.find('.annotation-tick.forward')).to.have.length(0);
+    expect(wrapper.find('.annotation-tick.reverse')).to.have.length(1);
+  });
+});

--- a/app/components/Annotation/presenter.jsx
+++ b/app/components/Annotation/presenter.jsx
@@ -3,6 +3,11 @@ import React, { Component, PropTypes } from 'react';
 const { bool, func, number, object } = PropTypes;
 
 
+const tickPosition = {
+  x: 5,
+  y: 4,
+};
+
 class Annotation extends Component {
   constructor(props, context) {
     super(props, context);
@@ -36,11 +41,6 @@ class Annotation extends Component {
     const isUnit = a.positionFrom === a.positionTo;
     const indexForTick = isReverse ? 0 : this.state.segments.length - 1;
 
-    /* eslint prefer-template: 0 */
-    const complementColor = ('000000' + (0xffffff ^ parseInt(
-      this.props.label.color.substr(1), 16
-    ))).slice(-6);
-
     return (
       <g
         className={`annotation
@@ -59,11 +59,13 @@ class Annotation extends Component {
               stroke={this.props.label.color}
             />
             {!isUnit && indexForTick === index ?
-              <circle
-                cx={isReverse ? line.x1 : line.x2}
-                cy={isReverse ? line.y1 : line.y2}
-                r="2"
-                fill={`#${complementColor}`}
+              <line
+                x1={isReverse ? line.x1 : line.x2}
+                x2={isReverse ? line.x1 + tickPosition.x : line.x2 - tickPosition.x}
+                y1={isReverse ? line.y1 : line.y2}
+                y2={isReverse ? line.y1 + tickPosition.y : line.y2 - tickPosition.y}
+                stroke={this.props.label.color}
+                className={`annotation-tick ${isReverse ? 'reverse' : 'forward'}`}
               /> : null
             }
           </g>

--- a/app/components/Annotation/presenter.jsx
+++ b/app/components/Annotation/presenter.jsx
@@ -32,9 +32,9 @@ class Annotation extends Component {
 
   render() {
     const a = this.props.annotation;
-    const isInverted = a.positionFrom > a.positionTo;
+    const isReverse = a.positionFrom > a.positionTo;
     const isUnit = a.positionFrom === a.positionTo;
-    const indexForTick = isInverted ? 0 : this.state.segments.length - 1;
+    const indexForTick = isReverse ? 0 : this.state.segments.length - 1;
 
     /* eslint prefer-template: 0 */
     const complementColor = ('000000' + (0xffffff ^ parseInt(
@@ -60,8 +60,8 @@ class Annotation extends Component {
             />
             {!isUnit && indexForTick === index ?
               <circle
-                cx={isInverted ? line.x1 : line.x2}
-                cy={isInverted ? line.y1 : line.y2}
+                cx={isReverse ? line.x1 : line.x2}
+                cy={isReverse ? line.y1 : line.y2}
                 r="2"
                 fill={`#${complementColor}`}
               /> : null

--- a/app/components/Annotation/presenter.jsx
+++ b/app/components/Annotation/presenter.jsx
@@ -31,23 +31,42 @@ class Annotation extends Component {
   }
 
   render() {
+    const a = this.props.annotation;
+    const isInverted = a.positionFrom > a.positionTo;
+    const isUnit = a.positionFrom === a.positionTo;
+    const indexForTick = isInverted ? 0 : this.state.segments.length - 1;
+
+    /* eslint prefer-template: 0 */
+    const complementColor = ('000000' + (0xffffff ^ parseInt(
+      this.props.label.color.substr(1), 16
+    ))).slice(-6);
+
     return (
       <g
         className={`annotation
-          ${this.props.label.isActive ? null : 'inactive'}
-          ${this.props.isSelected ? 'selected' : null}`}
+          ${this.props.label.isActive ? '' : 'inactive'}
+          ${this.props.isSelected ? 'selected' : ''}`}
         onClick={this.props.onClick}
       >
         {this.state.segments.map((line, index) =>
-          <line
-            key={index}
-            x1={line.x1}
-            x2={line.x2}
-            y1={line.y1}
-            y2={line.y2}
-            className="annotation-segment"
-            stroke={this.props.label.color}
-          />
+          <g key={index}>
+            <line
+              x1={line.x1}
+              x2={line.x2}
+              y1={line.y1}
+              y2={line.y2}
+              className="annotation-segment"
+              stroke={this.props.label.color}
+            />
+            {!isUnit && indexForTick === index ?
+              <circle
+                cx={isInverted ? line.x1 : line.x2}
+                cy={isInverted ? line.y1 : line.y2}
+                r="2"
+                fill={`#${complementColor}`}
+              /> : null
+            }
+          </g>
         )}
       </g>
     );

--- a/app/components/Annotation/presenter.jsx
+++ b/app/components/Annotation/presenter.jsx
@@ -1,12 +1,8 @@
 import React, { Component, PropTypes } from 'react';
+import Line from './Line';
 
 const { bool, func, number, object } = PropTypes;
 
-
-const tickPosition = {
-  x: 5,
-  y: 4,
-};
 
 class Annotation extends Component {
   constructor(props, context) {
@@ -49,26 +45,16 @@ class Annotation extends Component {
         onClick={this.props.onClick}
       >
         {this.state.segments.map((line, index) =>
-          <g key={index}>
-            <line
-              x1={line.x1}
-              x2={line.x2}
-              y1={line.y1}
-              y2={line.y2}
-              className="annotation-segment"
-              stroke={this.props.label.color}
-            />
-            {!isUnit && indexForTick === index ?
-              <line
-                x1={isReverse ? line.x1 : line.x2}
-                x2={isReverse ? line.x1 + tickPosition.x : line.x2 - tickPosition.x}
-                y1={isReverse ? line.y1 : line.y2}
-                y2={isReverse ? line.y1 + tickPosition.y : line.y2 - tickPosition.y}
-                stroke={this.props.label.color}
-                className={`annotation-tick ${isReverse ? 'reverse' : 'forward'}`}
-              /> : null
-            }
-          </g>
+          <Line
+            key={index}
+            x1={line.x1}
+            x2={line.x2}
+            y1={line.y1}
+            y2={line.y2}
+            color={this.props.label.color}
+            hasTick={!isUnit && indexForTick === index}
+            isReverse={isReverse}
+          />
         )}
       </g>
     );

--- a/app/components/Nucleotide/__tests__/Nucleotide-test.js
+++ b/app/components/Nucleotide/__tests__/Nucleotide-test.js
@@ -270,7 +270,7 @@ describe('<Nucleotide />', () => {
       expect(props.isInSelectionRange).to.be.true;
     });
 
-    it('returns isInSelectionRange and isSelected with inverted selections', () => {
+    it('returns isInSelectionRange and isSelected with reverse selections', () => {
       const state = {
         selection: {
           selections: [{ from: 10, to: 2}],

--- a/app/components/Visualizer/presenter.jsx
+++ b/app/components/Visualizer/presenter.jsx
@@ -18,7 +18,7 @@ export default class Visualizer extends Component {
         y: 10,
       },
       nucleotidesPerRow: 80,
-      nucleotidesRowHeight: 50,
+      nucleotidesRowHeight: 53,
       nucleotideWidth: 12,
       tracksPerRow: props.labels.size,
       trackHeight: 12,

--- a/app/components/Visualizer/presenter.jsx
+++ b/app/components/Visualizer/presenter.jsx
@@ -21,7 +21,7 @@ export default class Visualizer extends Component {
       nucleotidesRowHeight: 50,
       nucleotideWidth: 12,
       tracksPerRow: props.labels.size,
-      trackHeight: 6,
+      trackHeight: 12,
       rowHeight: 0,
       width: '100%',
       height: '100%',

--- a/app/defaults.js
+++ b/app/defaults.js
@@ -42,8 +42,8 @@ export const defaultLabels = new Immutable.List([
     isActive: true,
     annotations: new Immutable.List([
       {
-        positionFrom: 10,
-        positionTo: 20,
+        positionFrom: 20,
+        positionTo: 10,
         comment: 'ENSE000036121231-FWD',
       },
       {

--- a/app/scss/components/_annotations.scss
+++ b/app/scss/components/_annotations.scss
@@ -34,21 +34,18 @@
 
 .annotation {
   stroke-width: 4;
-  stroke-opacity: 0.4;
   stroke-linecap: round;
-  fill-opacity: 0.4;
+  opacity: 0.4;
 
   &.selected,
   &:hover {
     stroke-width: 6;
-    stroke-opacity: 1;
-    fill-opacity: 1;
+    opacity: 1;
     cursor: pointer;
   }
 
   &.inactive {
-    stroke-opacity: 0;
-    fill-opacity: 0;
+    opacity: 0;
   }
 
   .annotation-segment {}

--- a/app/scss/components/_annotations.scss
+++ b/app/scss/components/_annotations.scss
@@ -36,16 +36,19 @@
   stroke-width: 4;
   stroke-opacity: 0.4;
   stroke-linecap: round;
+  fill-opacity: 0.4;
 
   &.selected,
   &:hover {
     stroke-width: 6;
     stroke-opacity: 1;
+    fill-opacity: 1;
     cursor: pointer;
   }
 
   &.inactive {
     stroke-opacity: 0;
+    fill-opacity: 0;
   }
 
   .annotation-segment {}

--- a/app/utils/__tests__/positionning-test.js
+++ b/app/utils/__tests__/positionning-test.js
@@ -92,7 +92,7 @@ describe('utils/positionning', () => {
       expect(y2).to.equal(y1);
     });
 
-    it('handles inverted selections', () => {
+    it('handles reverse selections', () => {
       const { x1, x2, y1, y2 } = getAnnotationSegmentCoordinates(
         1, //indexFrom
         0, //indexTo

--- a/app/utils/__tests__/positionning-test.js
+++ b/app/utils/__tests__/positionning-test.js
@@ -91,5 +91,24 @@ describe('utils/positionning', () => {
       expect(x2).to.equal(NUCLEOTIDE_WIDTH + NUCLEOTIDE_WIDTH);
       expect(y2).to.equal(y1);
     });
+
+    it('handles inverted selections', () => {
+      const { x1, x2, y1, y2 } = getAnnotationSegmentCoordinates(
+        1, //indexFrom
+        0, //indexTo
+        1, //currentTrack
+        { x: 0, y: 0 },
+        NUCLEOTIDES_PER_ROW,
+        NUCLEOTIDE_WIDTH,
+        ROW_HEIGHT,
+        NUCLEOTIDE_HEIGHT,
+        5 //trackHeight
+      );
+
+      expect(x1).to.equal(NUCLEOTIDE_WIDTH / 2);
+      expect(y1).to.equal(NUCLEOTIDE_HEIGHT + 1 * 5);
+      expect(x2).to.equal(NUCLEOTIDE_WIDTH + NUCLEOTIDE_WIDTH);
+      expect(y2).to.equal(y1);
+    });
   });
 });

--- a/app/utils/positionning.js
+++ b/app/utils/positionning.js
@@ -43,15 +43,18 @@ export const getAnnotationSegmentCoordinates = (
   indexFrom, indexTo, currentTrack, visualizerMargin, nucleotidesPerRow,
   nucleotideWidth, rowHeight, nucleotidesRowHeight, trackHeight
 ) => {
+  const { from, to } = indexFrom < indexTo ?
+    { from: indexFrom, to: indexTo } : { from: indexTo, to: indexFrom };
+
   const nucleotideFromCoordinates = getNucleotideCoordinates(
-    indexFrom,
+    from,
     visualizerMargin,
     nucleotidesPerRow,
     nucleotideWidth,
     rowHeight
   );
   const nucleotideToCoordinates = getNucleotideCoordinates(
-    indexTo,
+    to,
     visualizerMargin,
     nucleotidesPerRow,
     nucleotideWidth,
@@ -73,15 +76,17 @@ export const getAnnotationSegments = (
   nucleotideWidth, rowHeight, nucleotidesRowHeight, trackHeight
 ) => {
   const segments = [];
+  const { from, to } = indexFrom < indexTo ?
+    { from: indexFrom, to: indexTo } : { from: indexTo, to: indexFrom };
 
-  let start = indexFrom;
-  for (let i = start + 1; i < indexTo; i++) {
+  let start = from;
+  for (let i = start + 1; i < to; i++) {
     if (! (i % nucleotidesPerRow)) {
       segments.push([start, i - 1]);
       start = i;
     }
   }
-  segments.push([start, indexTo]);
+  segments.push([start, to]);
 
   return segments.map((segment) =>
     getAnnotationSegmentCoordinates(


### PR DESCRIPTION
Annotation is not only a position range, it has an orientation too: always from 5'UTR to 3'UTR. Hence, [48 ; 54] and [54 ; 48] are two different annotations, forward and reverse respectively. One need to be able to distinguish them in the visualizer.

---

![screen shot 2016-06-30 at 09 27 39](https://cloud.githubusercontent.com/assets/217628/16480172/ed266d54-3ea4-11e6-8bae-b0dcbf91faf0.png)

 